### PR TITLE
Fixed typo in README

### DIFF
--- a/service_vpc/README.md
+++ b/service_vpc/README.md
@@ -27,7 +27,7 @@ positional arguments:
 
 optional arguments:
   -h, --help        show this help message and exit
-  -y, --yaml        Output to JSON
+  -y, --yaml        Output to YAML
 ```
     
 ### Output


### PR DESCRIPTION
Fixed a typo. JSON should have been YAML.